### PR TITLE
email invitations form added for inviting students

### DIFF
--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -1,0 +1,24 @@
+class InvitationsController < ApplicationController
+
+  before_action :get_classroom
+  after_action :verify_authorized
+
+  def create
+    authorize @classroom, :edit?
+    @emails = params[:invitation_emails].split(/,|\n/).map!(&:strip)
+
+    if @emails.any? && valid_emails?
+      InvitationMailer.invite(@emails, @classroom.id).deliver
+      redirect_to edit_classroom_path(@classroom), notice: "Invitations sent."
+    else
+      redirect_to edit_classroom_path(@classroom), alert: "Invalid email format"
+    end
+  end
+
+  private
+  def valid_emails?
+    @emails.each do |email|
+      return false unless /\A[^@]+@[^@]+\z/.match(email)
+    end
+  end
+end

--- a/app/mailers/invitation_mailer.rb
+++ b/app/mailers/invitation_mailer.rb
@@ -1,0 +1,8 @@
+class InvitationMailer < ActionMailer::Base
+  default from: "hello@helpcue.com"
+
+  def invite(emails, classroom_id)
+    @classroom = Classroom.find(classroom_id)
+    mail to: emails, subject: "You've been invited to a classroom on HelpCue"
+  end
+end

--- a/app/views/classrooms/edit.html.erb
+++ b/app/views/classrooms/edit.html.erb
@@ -16,7 +16,16 @@
   <% if policy(@classroom).remove_student? %>
     <div class="grid-unit narrow sidebar pull-right">
       <h4>Invite Students</h4>
-      <p>To invite students to this classroom, please share this access code: <span class='token'><%= @classroom.user_token %></span></p>
+      <p>To invite students to this classroom, please share this access code: <span class='token'><%= @classroom.user_token %></span> or use the form below.</p>
+
+      <%= form_tag classroom_invitations_path(@classroom) do %>
+        <div class="form-group">
+          <%= text_area_tag :invitation_emails, '', placeholder: "Separate multiple email addresses with commas or line breaks.", class: "form-input", rows: 4 %>
+        </div>
+        <div>
+          <%= submit_tag 'Send Invitation', class: 'btn btn-primary', id: 'invite-button' %>
+        </div>
+      <% end %>
     </div>
   <% end %>
   <div class="grid-unit wide">

--- a/app/views/invitation_mailer/invite.text.erb
+++ b/app/views/invitation_mailer/invite.text.erb
@@ -1,0 +1,7 @@
+Hi there,
+
+We'll be be using HelpCue for <%= @classroom.name %>. The help queue will facilitate more efficient use of everyone's time. It will also give you an opportunity to form groups around interests and problem areas.
+
+Accept this invitation by making an account at http://app.helpcue.com and then using the following token to join the classroom: <%= @classroom.user_token %>.
+
+If you haven't used HelpCue before then have a look at this short introductory video: http://youtu.be/ZWexCJfF0tY

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Helpcue::Application.routes.draw do
     resources :users, only: [:destroy]
     get "hashtags/:hashtag",   to: "hashtags#show",      as: :hashtag
     get "hashtags",   to: "hashtags#show",      as: :hashtag_search
+    resources :invitations, only: [:create]
   end
 
   # Development Environment

--- a/test/controllers/invitations_controller_test.rb
+++ b/test/controllers/invitations_controller_test.rb
@@ -1,0 +1,32 @@
+require 'test_helper'
+
+class InvitationsControllerTest < ActionController::TestCase
+  def setup
+    sign_in users(:teacher1)
+  end
+
+  test "should send email to all recipients" do
+    assert_difference 'ActionMailer::Base.deliveries.size', +1 do
+      post :create, classroom_id: classrooms(:one), invitation_emails: "student@email.com, student2@gmail.com"
+    end
+
+    invite_email = ActionMailer::Base.deliveries.last
+
+    assert_equal ["student@email.com", "student2@gmail.com"], invite_email.to
+    assert_redirected_to edit_classroom_path(classrooms(:one))
+  end
+
+  test "should give error with invalid email formats" do
+    post :create, classroom_id: classrooms(:one), invitation_emails: "student@email.com student2@gmail.com"
+
+    assert_equal "Invalid email format", flash[:alert]
+    assert_redirected_to edit_classroom_path(classrooms(:one))
+  end
+
+  test "should give error with no emails" do
+    post :create, classroom_id: classrooms(:one), invitation_emails: ""
+
+    assert_equal "Invalid email format", flash[:alert]
+    assert_redirected_to edit_classroom_path(classrooms(:one))
+  end
+end

--- a/test/mailers/invitation_mailer_test.rb
+++ b/test/mailers/invitation_mailer_test.rb
@@ -1,0 +1,14 @@
+require 'test_helper'
+
+class InvitationMailerTest < ActionMailer::TestCase
+  test "invite" do
+    emails = ["first@email.com", "2nd@email.com"]
+    mail = InvitationMailer.invite(emails, classrooms(:one).id)
+
+    assert_equal "You've been invited to a classroom on HelpCue", mail.subject
+    assert_equal emails, mail.to
+    assert_equal ["hello@helpcue.com"], mail.from
+    assert_match classrooms(:one).user_token, mail.body.encoded
+    assert_match classrooms(:one).name, mail.body.encoded
+  end
+end


### PR DESCRIPTION
Heather suggested

> Being able to send an email to students inviting them to the classroom directly from the app would be helpful!
