### PR TITLE
Escape tags

### DIFF
--- a/app/assets/javascripts/objects/requests_list.js.coffee
+++ b/app/assets/javascripts/objects/requests_list.js.coffee
@@ -16,6 +16,7 @@
         HelpCue.timeago()
         HelpCue.editable()
         HelpCue.tinysort()
+        HelpCue.hashTag()
 
   addRequest: (data) ->
     $placeholder = $('#placeholder')
@@ -24,6 +25,7 @@
       $('#requests-list').append(data.partial).append(data.expand_partial)
       HelpCue.timeago()
       HelpCue.editable()
+      HelpCue.hashTag()
 
   removeRequest: (data) ->
     $("#request#{data.request_id}").fadeOut 'slow', ->
@@ -32,8 +34,12 @@
         $('#placeholder').removeClass('dont-show')
 
   updateQuestion: (data) ->
-    data.question = "<p class='lightgrey-text'> Blank question </p>" unless data.question
-    $("#request#{data.request_id}").find("div.question").html(HelpCue.linkHashtags(data))
+    if data.question
+      $("#request#{data.request_id}").find("div.question").html(HelpCue.linkHashtags(data))
+    else
+      data.question = "<p class='lightgrey-text'> Blank question </p>"
+      $("#request#{data.request_id}").find("div.question").html(data.question)
+
     $request_modal = $("#request-expand-#{data.request_id}")
     if $request_modal.find(".editable.question").length
       $request_modal.find(".editable.question").editable('setValue', data.question)

--- a/app/assets/javascripts/queue.js.coffee
+++ b/app/assets/javascripts/queue.js.coffee
@@ -27,6 +27,7 @@ $ ->
 
     HelpCue.timeago()
     HelpCue.tinysort()
+    HelpCue.hashTag()
 
     $('.sort-link').on "ajax:success", (e, data) ->
       HelpCue.tinysort({sortType: data.sort_type})

--- a/app/assets/javascripts/request_actions.js.coffee
+++ b/app/assets/javascripts/request_actions.js.coffee
@@ -39,3 +39,4 @@ $ ->
     $.fn.editableform.buttons = '<button type="submit" class="editable-submit btn btn-small btn-success">Save</button>'+
     'or <a href="#" class="editable-cancel">cancel</a>'
     HelpCue.editable()
+    HelpCue.hashTag()

--- a/app/assets/javascripts/utilities.js.coffee
+++ b/app/assets/javascripts/utilities.js.coffee
@@ -43,9 +43,17 @@
 
 @HelpCue.linkHashtags = (data) ->
  hashpattern = /(#[A-Za-z0-9-_]+)/g;
+ data.question = data.question.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;')
  data.question.replace hashpattern, ($0) ->
    with_hash = $0
    "<a href='/classrooms/#{data.classroom_id}/hashtags/#{$0.replace(/#/, '')}'>" + with_hash + "</a>"
+
+@HelpCue.hashTag = ->
+  $('.request-item').each ->
+    $this = $(this)
+    question = $this.find("div.question")
+    unless question.find('.lightgrey-text').length
+      question.html(HelpCue.linkHashtags({question: question.text(), classroom_id: $('#queue_link').data('classroomid')}))
 
 @HelpCue.editable = ->
   $('.editable').editable(

--- a/app/decorators/request_decorator.rb
+++ b/app/decorators/request_decorator.rb
@@ -23,15 +23,15 @@ class RequestDecorator < Draper::Decorator
   end
 
   def question_or_placeholder
-    question.blank? ? "<p class='lightgrey-text'> Blank question </p>" : question
+    question.blank? ? "<p class='lightgrey-text'> Blank question </p>".html_safe : question
   end
 
   def answer_or_placeholder
-    answer.blank? ? "<p class='lightgrey-text'> No answer yet </p>" : answer
+    answer.blank? ? "<p class='lightgrey-text'> No answer yet </p>".html_safe : answer
   end
 
   def question_with_hashtags
-    h.linkify_hashtags(question_or_placeholder)
+    question_or_placeholder
   end
 
   def metoo_button

--- a/app/helpers/hashtags_helper.rb
+++ b/app/helpers/hashtags_helper.rb
@@ -1,10 +1,10 @@
 module HashtagsHelper
   def linkify_hashtags(hashtaggable_content)
     regex = SimpleHashtag::Hashtag::HASHTAG_REGEX
-    hashtagged_content = hashtaggable_content.to_s.gsub(regex) do
+    hashtagged_content = hashtaggable_content.gsub(regex) do
       link_to($&, classroom_hashtag_path(@classroom, $2), {class: :hashtag})
     end
-    hashtagged_content.html_safe
+    hashtagged_content
   end
 
   def render_hashtaggable(hashtaggable)


### PR DESCRIPTION
Because hashtags are turned into links ... we were executing all html code that the user put into the question box. This of course is a bad idea. It's tough figuring out how to escape the input and then make the hashtags into html links. Hopefully this is resolved now.
